### PR TITLE
fix: update benchmarks to use v1.0.0 API

### DIFF
--- a/bench/dispatch_benchmark.exs
+++ b/bench/dispatch_benchmark.exs
@@ -74,7 +74,7 @@ end
 
 # Create test session
 session_id = "bench_session_#{:rand.uniform(1_000_000)}"
-{:ok, _pid} = Phoenix.SessionProcess.start(session_id, BenchSession)
+{:ok, _pid} = Phoenix.SessionProcess.start_session(session_id, module: BenchSession)
 
 IO.puts("Session started: #{session_id}\n")
 
@@ -115,15 +115,11 @@ Enum.each([100, 500, 1000], fn count ->
   {time, results} =
     :timer.tc(fn ->
       Enum.map(1..count, fn _ ->
-        Phoenix.SessionProcess.dispatch_async(session_id, "bench.increment", nil, async: true)
+        Phoenix.SessionProcess.dispatch_async(session_id, "bench.async_increment")
       end)
     end)
 
-  success_count =
-    Enum.count(results, fn
-      {:ok, _cancel_fn} -> true
-      _ -> false
-    end)
+  success_count = Enum.count(results, &(&1 == :ok))
 
   rate = Float.round(success_count / (time / 1_000_000), 2)
   avg_time = Float.round(time / count / 1000, 3)

--- a/bench/session_benchmark.exs
+++ b/bench/session_benchmark.exs
@@ -23,7 +23,7 @@ IO.puts(String.duplicate("=", 50))
 IO.puts("Warming up...")
 
 for _i <- 1..100 do
-  SessionProcess.start("warmup_#{System.unique_integer()}")
+  SessionProcess.start_session("warmup_#{System.unique_integer()}")
 end
 
 # Clear warmup sessions
@@ -64,7 +64,7 @@ IO.puts(String.duplicate("-", 35))
 
 # Create test sessions
 Enum.each(1..100, fn i ->
-  SessionProcess.start("comm_test_#{i}")
+  SessionProcess.start_session("comm_test_#{i}")
 end)
 
 # Benchmark calls vs casts
@@ -110,7 +110,7 @@ Enum.each(memory_tests, fn count ->
 
   # Create sessions
   Enum.each(1..count, fn i ->
-    SessionProcess.start("memory_test_#{i}")
+    SessionProcess.start_session("memory_test_#{i}")
   end)
 
   # Measure memory
@@ -129,7 +129,7 @@ IO.puts(String.duplicate("-", 32))
 
 # Create sessions for lookup tests
 Enum.each(1..1000, fn i ->
-  SessionProcess.start("lookup_test_#{i}")
+  SessionProcess.start_session("lookup_test_#{i}")
 end)
 
 lookup_tests = [100, 1000, 5000]
@@ -161,13 +161,13 @@ Enum.each(error_tests, fn {scenario, test_id} ->
     :timer.tc(fn ->
       case scenario do
         :invalid_session_id ->
-          SessionProcess.start(test_id)
+          SessionProcess.start_session(test_id)
 
         :session_not_found ->
           SessionProcess.call(test_id, :ping)
 
         :timeout_scenario ->
-          SessionProcess.start(test_id)
+          SessionProcess.start_session(test_id)
           SessionProcess.call(test_id, :slow_operation, 1)
       end
     end)
@@ -181,7 +181,7 @@ IO.puts(String.duplicate("-", 23))
 
 1..10_000
 |> Enum.each(fn i ->
-  SessionProcess.start("cleanup_test_#{i}")
+  SessionProcess.start_session("cleanup_test_#{i}")
 end)
 
 session_count = length(SessionProcess.list_session())
@@ -238,7 +238,7 @@ stress_test = fn concurrent_ops ->
         Task.async(fn ->
           session_id = "stress_#{i}_#{System.unique_integer()}"
 
-          case SessionProcess.start(session_id) do
+          case SessionProcess.start_session(session_id) do
             {:ok, _pid} ->
               SessionProcess.call(session_id, :ping)
               SessionProcess.terminate(session_id)

--- a/bench/simple_bench.exs
+++ b/bench/simple_bench.exs
@@ -25,7 +25,7 @@ IO.puts("\n1. Session Creation (100 sessions)")
 {time, results} =
   :timer.tc(fn ->
     Enum.map(1..100, fn i ->
-      SessionProcess.start("quick_test_#{i}")
+      SessionProcess.start_session("quick_test_#{i}")
     end)
   end)
 
@@ -49,7 +49,7 @@ IO.puts("\n2. Session Communication (50 calls)")
     |> Task.await_many(5000)
   end)
 
-call_success = Enum.count(call_results, &match?({:ok, _}, &1))
+call_success = Enum.count(call_results, &(&1 == :pong))
 
 IO.puts(
   "#{call_success}/50 calls completed in #{call_time / 1000}ms (#{Float.round(call_success / (call_time / 1_000_000), 2)} calls/sec)"


### PR DESCRIPTION
## Summary
- Replace deprecated `SessionProcess.start()` with `SessionProcess.start_session()` in all bench files
- Fix `dispatch_benchmark.exs` to use keyword opts for `start_session/2`
- Fix async dispatch and result matching patterns
- Fixes Benchmark CI workflow that has been failing consistently

## Test plan
- [x] `mix run bench/simple_bench.exs` runs successfully